### PR TITLE
Feature/date layer customization options & Drop Aplite Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
             "BackgroundColor",
             "TimeTextColor",
             "DateTextColor",
+            "WeekdayTextColor",
             "BatteryFrameColor",
             "BatteryFillColor",
             "ShowSeconds",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
             "WeatherTextColor",
             "WeatherAxisTickColor",
             "WeatherIndicatorColor",
+            "WeatherSeparatorColor",
             "WeatherMaxTempColor",
             "WeatherCurrentTempColor",
             "WeatherMinTempColor",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
             "TimeTextColor",
             "DateTextColor",
             "WeekdayTextColor",
+            "DateSeparatorColor",
             "BatteryFrameColor",
             "BatteryFillColor",
             "ShowSeconds",
@@ -89,7 +90,6 @@
         },
         "sdkVersion": "3",
         "targetPlatforms": [
-            "aplite",
             "basalt",
             "diorite",
             "flint",

--- a/src/c/app_messaging/app_messaging.c
+++ b/src/c/app_messaging/app_messaging.c
@@ -210,6 +210,7 @@ static bool read_configuration_properties(
     APPLY_COLOR(MESSAGE_KEY_WeatherMinTempColor, WeatherMinTempColor);
     APPLY_COLOR(MESSAGE_KEY_WeatherAxisTickColor, WeatherAxisTickColor);
     APPLY_COLOR(MESSAGE_KEY_WeatherIndicatorColor, WeatherIndicatorColor);
+    APPLY_COLOR(MESSAGE_KEY_WeatherSeparatorColor, WeatherSeparatorColor);
 
 #if defined(PBL_COLOR)
     APPLY_COLOR(MESSAGE_KEY_ForecastTempColorM10, ForecastTempColorM10);

--- a/src/c/app_messaging/app_messaging.c
+++ b/src/c/app_messaging/app_messaging.c
@@ -200,6 +200,7 @@ static bool read_configuration_properties(
     APPLY_COLOR(MESSAGE_KEY_TimeTextColor, TimeTextColor);
     APPLY_COLOR(MESSAGE_KEY_DateTextColor, DateTextColor);
     APPLY_COLOR(MESSAGE_KEY_WeekdayTextColor, WeekdayTextColor);
+    APPLY_COLOR(MESSAGE_KEY_DateSeparatorColor, DateSeparatorColor);
     APPLY_COLOR(MESSAGE_KEY_BatteryFrameColor, BatteryFrameColor);
     APPLY_COLOR(MESSAGE_KEY_BatteryFillColor, BatteryFillColor);
     APPLY_COLOR(MESSAGE_KEY_BatteryLowColor, BatteryLowColor);

--- a/src/c/app_messaging/app_messaging.c
+++ b/src/c/app_messaging/app_messaging.c
@@ -199,6 +199,7 @@ static bool read_configuration_properties(
     APPLY_COLOR(MESSAGE_KEY_BackgroundColor, BackgroundColor);
     APPLY_COLOR(MESSAGE_KEY_TimeTextColor, TimeTextColor);
     APPLY_COLOR(MESSAGE_KEY_DateTextColor, DateTextColor);
+    APPLY_COLOR(MESSAGE_KEY_WeekdayTextColor, WeekdayTextColor);
     APPLY_COLOR(MESSAGE_KEY_BatteryFrameColor, BatteryFrameColor);
     APPLY_COLOR(MESSAGE_KEY_BatteryFillColor, BatteryFillColor);
     APPLY_COLOR(MESSAGE_KEY_BatteryLowColor, BatteryLowColor);

--- a/src/c/settings/clay_settings.c
+++ b/src/c/settings/clay_settings.c
@@ -14,7 +14,6 @@ const char *THEME_DEFAULT = THEME_LIGHT_STR;
 static ClaySettings s_settings;
 
 void clay_log_settings_debug(const char *context_label, ClaySettings *settings) {
-#if !defined(PBL_PLATFORM_APLITE)
     const char *label = context_label ? context_label : "settings";
 
     APP_LOG(
@@ -31,12 +30,13 @@ void clay_log_settings_debug(const char *context_label, ClaySettings *settings) 
 
     APP_LOG(
         APP_LOG_LEVEL_DEBUG,
-        "%s colors bg=%lu time=%lu date=%lu weekday=%lu weather=%lu max=%lu cur=%lu min=%lu tick=%lu ind=%lu step=%lu hr=%lu bat_low=%lu",
+        "%s colors bg=%lu time=%lu date=%lu weekday=%lu separator=%lu weather=%lu max=%lu cur=%lu min=%lu tick=%lu ind=%lu step=%lu hr=%lu bat_low=%lu",
         label,
         (unsigned long) settings->BackgroundColor.argb,
         (unsigned long) settings->TimeTextColor.argb,
         (unsigned long) settings->DateTextColor.argb,
         (unsigned long) settings->WeekdayTextColor.argb,
+        (unsigned long) settings->DateSeparatorColor.argb,
         (unsigned long) settings->WeatherTextColor.argb,
         (unsigned long) settings->WeatherMaxTempColor.argb,
         (unsigned long) settings->WeatherCurrentTempColor.argb,
@@ -119,7 +119,6 @@ void clay_log_settings_debug(const char *context_label, ClaySettings *settings) 
         settings->WeatherUpdateIntervalMinutes,
         (double) settings->TimeRowRatio
     );
-#endif
 }
 
 static bool is_row_widget_valid(const uint8_t widget) {
@@ -212,6 +211,7 @@ static ClaySettings *clay_reset_to_default_settings() {
     // Date Layer
     settings->DateTextColor = textColor;
     settings->WeekdayTextColor = textColor;
+    settings->DateSeparatorColor = textColor;
 
     // Battery Bar Layer
     settings->BatteryFrameColor = foregroundColor;

--- a/src/c/settings/clay_settings.c
+++ b/src/c/settings/clay_settings.c
@@ -30,7 +30,7 @@ void clay_log_settings_debug(const char *context_label, ClaySettings *settings) 
 
     APP_LOG(
         APP_LOG_LEVEL_DEBUG,
-        "%s colors bg=%lu time=%lu date=%lu weekday=%lu separator=%lu weather=%lu max=%lu cur=%lu min=%lu tick=%lu ind=%lu step=%lu hr=%lu bat_low=%lu",
+        "%s colors bg=%lu time=%lu date=%lu weekday=%lu separator=%lu weather=%lu max=%lu cur=%lu min=%lu tick=%lu ind=%lu weather_sep=%lu step=%lu hr=%lu bat_low=%lu",
         label,
         (unsigned long) settings->BackgroundColor.argb,
         (unsigned long) settings->TimeTextColor.argb,
@@ -43,6 +43,7 @@ void clay_log_settings_debug(const char *context_label, ClaySettings *settings) 
         (unsigned long) settings->WeatherMinTempColor.argb,
         (unsigned long) settings->WeatherAxisTickColor.argb,
         (unsigned long) settings->WeatherIndicatorColor.argb,
+        (unsigned long) settings->WeatherSeparatorColor.argb,
         (unsigned long) settings->StepcountTextColor.argb,
         (unsigned long) settings->HeartrateTextColor.argb,
         (unsigned long) settings->BatteryLowColor.argb
@@ -225,6 +226,7 @@ static ClaySettings *clay_reset_to_default_settings() {
     settings->WeatherMinTempColor = GColorPictonBlue;
     settings->WeatherAxisTickColor = GColorDarkGray;
     settings->WeatherIndicatorColor = textColor;
+    settings->WeatherSeparatorColor = GColorLightGray;
 
 #if defined(PBL_COLOR)
     // Forecast Graph Colors

--- a/src/c/settings/clay_settings.c
+++ b/src/c/settings/clay_settings.c
@@ -31,11 +31,12 @@ void clay_log_settings_debug(const char *context_label, ClaySettings *settings) 
 
     APP_LOG(
         APP_LOG_LEVEL_DEBUG,
-        "%s colors bg=%lu time=%lu date=%lu weather=%lu max=%lu cur=%lu min=%lu tick=%lu ind=%lu step=%lu hr=%lu bat_low=%lu",
+        "%s colors bg=%lu time=%lu date=%lu weekday=%lu weather=%lu max=%lu cur=%lu min=%lu tick=%lu ind=%lu step=%lu hr=%lu bat_low=%lu",
         label,
         (unsigned long) settings->BackgroundColor.argb,
         (unsigned long) settings->TimeTextColor.argb,
         (unsigned long) settings->DateTextColor.argb,
+        (unsigned long) settings->WeekdayTextColor.argb,
         (unsigned long) settings->WeatherTextColor.argb,
         (unsigned long) settings->WeatherMaxTempColor.argb,
         (unsigned long) settings->WeatherCurrentTempColor.argb,
@@ -210,6 +211,7 @@ static ClaySettings *clay_reset_to_default_settings() {
     settings->TimeTextColor = textColor;
     // Date Layer
     settings->DateTextColor = textColor;
+    settings->WeekdayTextColor = textColor;
 
     // Battery Bar Layer
     settings->BatteryFrameColor = foregroundColor;

--- a/src/c/settings/clay_settings.h
+++ b/src/c/settings/clay_settings.h
@@ -7,7 +7,7 @@
 // Persistent storage key
 #define SETTINGS_KEY PERSIST_KEY_SETTINGS
 #define SETTINGS_VERSION_KEY PERSIST_KEY_SETTINGS_VERSION
-#define SETTINGS_VERSION 21
+#define SETTINGS_VERSION 22
 
 // Theme Values
 #define THEME_LIGHT_STR "LIGHT"
@@ -19,6 +19,7 @@ typedef struct ClaySettings {
     GColor BackgroundColor;
     GColor TimeTextColor;
     GColor DateTextColor;
+    GColor WeekdayTextColor;
     GColor BatteryFrameColor;
     GColor BatteryFillColor;
     GColor BatteryLowColor;

--- a/src/c/settings/clay_settings.h
+++ b/src/c/settings/clay_settings.h
@@ -7,7 +7,7 @@
 // Persistent storage key
 #define SETTINGS_KEY PERSIST_KEY_SETTINGS
 #define SETTINGS_VERSION_KEY PERSIST_KEY_SETTINGS_VERSION
-#define SETTINGS_VERSION 23
+#define SETTINGS_VERSION 24
 
 // Theme Values
 #define THEME_LIGHT_STR "LIGHT"
@@ -30,6 +30,7 @@ typedef struct ClaySettings {
     GColor WeatherMinTempColor;
     GColor WeatherAxisTickColor;
     GColor WeatherIndicatorColor;
+    GColor WeatherSeparatorColor;
 #if defined(PBL_COLOR)
     GColor ForecastTempColorM10;
     GColor ForecastTempColor0;

--- a/src/c/settings/clay_settings.h
+++ b/src/c/settings/clay_settings.h
@@ -7,7 +7,7 @@
 // Persistent storage key
 #define SETTINGS_KEY PERSIST_KEY_SETTINGS
 #define SETTINGS_VERSION_KEY PERSIST_KEY_SETTINGS_VERSION
-#define SETTINGS_VERSION 22
+#define SETTINGS_VERSION 23
 
 // Theme Values
 #define THEME_LIGHT_STR "LIGHT"
@@ -20,6 +20,7 @@ typedef struct ClaySettings {
     GColor TimeTextColor;
     GColor DateTextColor;
     GColor WeekdayTextColor;
+    GColor DateSeparatorColor;
     GColor BatteryFrameColor;
     GColor BatteryFillColor;
     GColor BatteryLowColor;

--- a/src/c/ui/layer/date.c
+++ b/src/c/ui/layer/date.c
@@ -8,7 +8,12 @@
 #include "../../ui/layer_factory.h"
 #include "../ui_state.h"
 
-// get the uppercase version if the char
+typedef struct DateLayerData {
+    DottedTextLayer *weekday_layer;
+    DottedTextLayer *date_digits_layer;
+} DateLayerData;
+
+// get the uppercase version of the char
 static char upper(char c) {
     if (c >= 'a' && c <= 'z')
         return (c = c + 'A' - 'a');
@@ -16,73 +21,120 @@ static char upper(char c) {
         return c;
 }
 
-static void update_date_for_layer(DottedTextLayer *date_layer) {
+static void date_layer_update_proc(Layer *layer, GContext *ctx) {
+    DateLayerData *data = layer_get_data(layer);
+    GRect bounds = layer_get_bounds(layer);
+
+    int weekday_width = 0;
+    int digits_width = 0;
+    int total_width = 0;
+    const int spacing = 4; // spacing in pixels between weekday and date digits
+
+    if (data->weekday_layer) {
+        weekday_width = dotted_text_layer_get_content_width(data->weekday_layer);
+        total_width += weekday_width;
+    }
+    if (data->date_digits_layer) {
+        digits_width = dotted_text_layer_get_content_width(data->date_digits_layer);
+        total_width += digits_width;
+    }
+
+    if (weekday_width > 0 && digits_width > 0) {
+        total_width += spacing;
+    }
+
+    int current_x = bounds.size.w - total_width;
+
+    if (data->weekday_layer) {
+        if (weekday_width > 0) {
+            layer_set_frame((Layer *) data->weekday_layer, GRect(current_x, 0, weekday_width, bounds.size.h));
+            current_x += weekday_width + spacing;
+        } else {
+            layer_set_frame((Layer *) data->weekday_layer, GRect(0, 0, 0, 0));
+        }
+    }
+
+    if (data->date_digits_layer) {
+        if (digits_width > 0) {
+            layer_set_frame((Layer *) data->date_digits_layer, GRect(current_x, 0, digits_width, bounds.size.h));
+        } else {
+            layer_set_frame((Layer *) data->date_digits_layer, GRect(0, 0, 0, 0));
+        }
+    }
+}
+
+static void update_date_for_layer(Layer *container_layer) {
+    DateLayerData *data = layer_get_data(container_layer);
+    if (data == NULL) {
+        return;
+    }
+
     // Get a tm structure
     time_t temp = time(NULL);
     struct tm *tick_time = localtime(&temp);
 
-    // Write the current day, month and year into a buffer
-    static char s_buffer[32];
-    char date_format[32];
-    strcpy(date_format, "");
-    if (clay_get_settings()->ShowWeekdayAbbreviation) {
-        strcat(date_format, "%a ");
+    ClaySettings *settings = clay_get_settings();
+    Theme *theme = theme_get_theme();
+
+    // 1. Weekday Abbreviation
+    if (data->weekday_layer) {
+        if (settings->ShowWeekdayAbbreviation) {
+            char weekday_buffer[16];
+            strftime(weekday_buffer, sizeof(weekday_buffer), "%a", tick_time);
+
+            // Remove the third character of weekday abbreviation
+            int idxToDel = 2;
+            if (strlen(weekday_buffer) > (size_t) idxToDel) {
+                memmove(&weekday_buffer[idxToDel], &weekday_buffer[idxToDel + 1], strlen(weekday_buffer) - idxToDel);
+            }
+
+            // Convert to uppercase (if enabled)
+            if (settings->WeekdayAbbreviationUppercase) {
+                for (int j = 0; j < 2; j++) {
+                    weekday_buffer[j] = upper(weekday_buffer[j]);
+                }
+            }
+            dotted_text_layer_set_text(data->weekday_layer, weekday_buffer);
+            dotted_text_layer_set_color(data->weekday_layer, theme->WeekdayTextColor);
+        } else {
+            dotted_text_layer_set_text(data->weekday_layer, NULL);
+        }
     }
 
-    strcat(date_format, "%d.%m");
-
-    if (clay_get_settings()->ShowYear) {
-        strcat(date_format, ".%y");
-    }
-
-    strftime(s_buffer, sizeof(s_buffer), date_format, tick_time);
-
-    // Remove the third character of weekday abbreviation
-    if (clay_get_settings()->ShowWeekdayAbbreviation) {
-        int idxToDel = 2;
-        memmove(&s_buffer[idxToDel], &s_buffer[idxToDel + 1], strlen(s_buffer) - idxToDel);
-
-        // Convert to uppercase (if enabled)
-        if (clay_get_settings()->WeekdayAbbreviationUppercase) {
-            for (int j = 0; j < 2; j++) {
-                s_buffer[j] = upper(s_buffer[j]);
-            }
+    // 2. Date Digits
+    if (data->date_digits_layer) {
+        char digits_buffer[16];
+        char date_format[16] = "%d.%m";
+        if (settings->ShowYear) {
+            strcat(date_format, ".%y");
         }
-    }
+        strftime(digits_buffer, sizeof(digits_buffer), date_format, tick_time);
 
-    if (!clay_get_settings()->DateZeroPadding) {
-        char *p = s_buffer;
-        
-        // If there is a weekday, skip it. The weekday is followed by a space.
-        if (clay_get_settings()->ShowWeekdayAbbreviation) {
-            while (*p && *p != ' ') {
-                p++;
-            }
-            if (*p == ' ') {
-                p++;
-            }
-        }
-        
-        // Now p points to the start of the day digits.
-        if (*p == '0') {
-            memmove(p, p + 1, strlen(p + 1) + 1);
-        }
-        
-        // Find the first '.' separator.
-        while (*p && *p != '.') {
-            p++;
-        }
-        
-        if (*p == '.') {
-            p++; // Point to the start of the month digits
+        if (!settings->DateZeroPadding) {
+            char *p = digits_buffer;
+
+            // Now p points to the start of the day digits.
             if (*p == '0') {
                 memmove(p, p + 1, strlen(p + 1) + 1);
             }
+
+            // Find the first '.' separator.
+            while (*p && *p != '.') {
+                p++;
+            }
+
+            if (*p == '.') {
+                p++; // Point to the start of the month digits
+                if (*p == '0') {
+                    memmove(p, p + 1, strlen(p + 1) + 1);
+                }
+            }
         }
+        dotted_text_layer_set_text(data->date_digits_layer, digits_buffer);
+        dotted_text_layer_set_color(data->date_digits_layer, theme->DateTextColor);
     }
 
-    // Display this date on the DottedTextLayer
-    dotted_text_layer_set_text(date_layer, s_buffer);
+    layer_mark_dirty(container_layer);
 }
 
 // Backward compatible wrapper (called by tick listener)
@@ -96,25 +148,53 @@ void update_date() {
 
 // creates the date layer
 Layer *create_date_layer(LayerBuilder builder) {
-    DottedTextLayer *date_layer = layer_factory_create_dotted_text_layer(
+    Layer *container = layer_factory_create_custom_layer_with_data(
         builder,
-        theme_get_theme()->DateTextColor,
-        HORIZONTAL_ALIGN_RIGHT,
+        date_layer_update_proc,
+        sizeof(DateLayerData)
+    );
+    DateLayerData *data = layer_get_data(container);
+
+    ClaySettings *settings = clay_get_settings();
+    Theme *theme = theme_get_theme();
+    LayerBuilder child_builder = layer_builder_from_rect(container, GRect(0, 0, builder.bounds.size.w, builder.bounds.size.h));
+
+    data->weekday_layer = layer_factory_create_dotted_text_layer(
+        child_builder,
+        theme->WeekdayTextColor,
+        HORIZONTAL_ALIGN_LEFT,
         VERTICAL_ALIGN_TOP,
         NULL
     );
-    if (clay_get_settings()->DotAutoScale) {
-        dotted_text_layer_set_auto_scale(date_layer, true);
+    data->date_digits_layer = layer_factory_create_dotted_text_layer(
+        child_builder,
+        theme->DateTextColor,
+        HORIZONTAL_ALIGN_LEFT,
+        VERTICAL_ALIGN_TOP,
+        NULL
+    );
+
+    if (settings->DotAutoScale) {
+        dotted_text_layer_set_auto_scale(data->weekday_layer, true);
+        dotted_text_layer_set_auto_scale(data->date_digits_layer, true);
     } else {
-        dotted_text_layer_set_scale_factor(date_layer, clay_get_settings()->DotScaleFactor);
+        dotted_text_layer_set_scale_factor(data->weekday_layer, settings->DotScaleFactor);
+        dotted_text_layer_set_scale_factor(data->date_digits_layer, settings->DotScaleFactor);
     }
 
-    update_date_for_layer(date_layer);
+    update_date_for_layer(container);
 
-    return (Layer *) date_layer;
+    return container;
 }
 
 // destroys the date layer
 void destroy_date_layer(Layer *layer) {
-    dotted_text_layer_destroy(layer);
+    DateLayerData *data = layer_get_data(layer);
+    if (data->weekday_layer) {
+        dotted_text_layer_destroy(data->weekday_layer);
+    }
+    if (data->date_digits_layer) {
+        dotted_text_layer_destroy(data->date_digits_layer);
+    }
+    layer_destroy(layer);
 }

--- a/src/c/ui/layer/date.c
+++ b/src/c/ui/layer/date.c
@@ -8,57 +8,96 @@
 #include "../../ui/layer_factory.h"
 #include "../ui_state.h"
 
+typedef enum {
+    DATE_PART_WEEKDAY = 0,
+    DATE_PART_DAY = 1,
+    DATE_PART_SEP1 = 2,
+    DATE_PART_MONTH = 3,
+    DATE_PART_SEP2 = 4,
+    DATE_PART_YEAR = 5,
+    DATE_PART_COUNT = 6
+} DatePart;
+
 typedef struct DateLayerData {
-    DottedTextLayer *weekday_layer;
-    DottedTextLayer *date_digits_layer;
+    DottedTextLayer *parts[DATE_PART_COUNT];
 } DateLayerData;
 
-// get the uppercase version of the char
-static char upper(char c) {
-    if (c >= 'a' && c <= 'z')
-        return (c = c + 'A' - 'a');
-    else
-        return c;
-}
+#define UPPER(c) (((c) >= 'a' && (c) <= 'z') ? ((c) - 32) : (c))
 
 static void date_layer_update_proc(Layer *layer, GContext *ctx) {
     DateLayerData *data = layer_get_data(layer);
     GRect bounds = layer_get_bounds(layer);
+    ClaySettings *settings = clay_get_settings();
 
-    int weekday_width = 0;
-    int digits_width = 0;
+    // 1. Calculate metrics and dynamic spacing
+    float scale_factor = 1.0f;
+    if (settings->DotAutoScale) {
+        int base_height = (5 * settings->DotHeight) + (4 * settings->DotVerticalGap);
+        if (base_height > 0) {
+            scale_factor = (float) bounds.size.h / (float) base_height;
+        }
+    } else {
+        scale_factor = settings->DotScaleFactor;
+    }
+    if (scale_factor <= 0.0f) {
+        scale_factor = 1.0f;
+    }
+
+    float dot_width = (float) settings->DotWidth * scale_factor;
+    int char_spacing = (int) (2.0f * dot_width + 0.5f);
+    if (char_spacing < 1) {
+        char_spacing = 1;
+    }
+    int weekday_spacing = (int) (3.0f * dot_width + 0.5f);
+    if (weekday_spacing < 1) {
+        weekday_spacing = 1;
+    }
+
+    // 2. Measure widths
+    int widths[DATE_PART_COUNT] = {0};
     int total_width = 0;
-    const int spacing = 4; // spacing in pixels between weekday and date digits
 
-    if (data->weekday_layer) {
-        weekday_width = dotted_text_layer_get_content_width(data->weekday_layer);
-        total_width += weekday_width;
-    }
-    if (data->date_digits_layer) {
-        digits_width = dotted_text_layer_get_content_width(data->date_digits_layer);
-        total_width += digits_width;
+    for (int i = 0; i < DATE_PART_COUNT; i++) {
+        if (data->parts[i]) {
+            widths[i] = dotted_text_layer_get_content_width(data->parts[i]);
+            if (widths[i] > 0) {
+                total_width += widths[i];
+            }
+        }
     }
 
-    if (weekday_width > 0 && digits_width > 0) {
-        total_width += spacing;
+    // Add spacing between elements
+    if (widths[DATE_PART_WEEKDAY] > 0 && (widths[DATE_PART_DAY] > 0 || widths[DATE_PART_MONTH] > 0)) {
+        total_width += weekday_spacing;
+    }
+    if (widths[DATE_PART_DAY] > 0 && widths[DATE_PART_SEP1] > 0) {
+        total_width += char_spacing;
+    }
+    if (widths[DATE_PART_SEP1] > 0 && widths[DATE_PART_MONTH] > 0) {
+        total_width += char_spacing;
+    }
+    if (widths[DATE_PART_MONTH] > 0 && widths[DATE_PART_SEP2] > 0) {
+        total_width += char_spacing;
+    }
+    if (widths[DATE_PART_SEP2] > 0 && widths[DATE_PART_YEAR] > 0) {
+        total_width += char_spacing;
     }
 
     int current_x = bounds.size.w - total_width;
 
-    if (data->weekday_layer) {
-        if (weekday_width > 0) {
-            layer_set_frame((Layer *) data->weekday_layer, GRect(current_x, 0, weekday_width, bounds.size.h));
-            current_x += weekday_width + spacing;
-        } else {
-            layer_set_frame((Layer *) data->weekday_layer, GRect(0, 0, 0, 0));
-        }
-    }
-
-    if (data->date_digits_layer) {
-        if (digits_width > 0) {
-            layer_set_frame((Layer *) data->date_digits_layer, GRect(current_x, 0, digits_width, bounds.size.h));
-        } else {
-            layer_set_frame((Layer *) data->date_digits_layer, GRect(0, 0, 0, 0));
+    // Position layers
+    for (int i = 0; i < DATE_PART_COUNT; i++) {
+        if (data->parts[i]) {
+            if (widths[i] > 0) {
+                layer_set_frame((Layer *) data->parts[i], GRect(current_x, 0, widths[i], bounds.size.h));
+                int next_spacing = char_spacing;
+                if (i == DATE_PART_WEEKDAY) {
+                    next_spacing = weekday_spacing;
+                }
+                current_x += widths[i] + next_spacing;
+            } else {
+                layer_set_frame((Layer *) data->parts[i], GRect(0, 0, 0, 0));
+            }
         }
     }
 }
@@ -76,62 +115,69 @@ static void update_date_for_layer(Layer *container_layer) {
     ClaySettings *settings = clay_get_settings();
     Theme *theme = theme_get_theme();
 
-    // 1. Weekday Abbreviation
-    if (data->weekday_layer) {
+    // 1. Set text on active parts
+    if (data->parts[DATE_PART_WEEKDAY]) {
         if (settings->ShowWeekdayAbbreviation) {
-            char weekday_buffer[16];
+            char weekday_buffer[8];
             strftime(weekday_buffer, sizeof(weekday_buffer), "%a", tick_time);
-
-            // Remove the third character of weekday abbreviation
-            int idxToDel = 2;
-            if (strlen(weekday_buffer) > (size_t) idxToDel) {
-                memmove(&weekday_buffer[idxToDel], &weekday_buffer[idxToDel + 1], strlen(weekday_buffer) - idxToDel);
-            }
-
-            // Convert to uppercase (if enabled)
+            weekday_buffer[2] = '\0';
             if (settings->WeekdayAbbreviationUppercase) {
-                for (int j = 0; j < 2; j++) {
-                    weekday_buffer[j] = upper(weekday_buffer[j]);
-                }
+                weekday_buffer[0] = UPPER(weekday_buffer[0]);
+                weekday_buffer[1] = UPPER(weekday_buffer[1]);
             }
-            dotted_text_layer_set_text(data->weekday_layer, weekday_buffer);
-            dotted_text_layer_set_color(data->weekday_layer, theme->WeekdayTextColor);
+            dotted_text_layer_set_text(data->parts[DATE_PART_WEEKDAY], weekday_buffer);
         } else {
-            dotted_text_layer_set_text(data->weekday_layer, NULL);
+            dotted_text_layer_set_text(data->parts[DATE_PART_WEEKDAY], NULL);
         }
     }
 
-    // 2. Date Digits
-    if (data->date_digits_layer) {
-        char digits_buffer[16];
-        char date_format[16] = "%d.%m";
+    if (data->parts[DATE_PART_DAY]) {
+        char day_buffer[8];
+        strftime(day_buffer, sizeof(day_buffer), "%d", tick_time);
+        if (!settings->DateZeroPadding && day_buffer[0] == '0') {
+            day_buffer[0] = day_buffer[1];
+            day_buffer[1] = '\0';
+        }
+        dotted_text_layer_set_text(data->parts[DATE_PART_DAY], day_buffer);
+    }
+
+    if (data->parts[DATE_PART_MONTH]) {
+        char month_buffer[8];
+        strftime(month_buffer, sizeof(month_buffer), "%m", tick_time);
+        if (!settings->DateZeroPadding && month_buffer[0] == '0') {
+            month_buffer[0] = month_buffer[1];
+            month_buffer[1] = '\0';
+        }
+        dotted_text_layer_set_text(data->parts[DATE_PART_MONTH], month_buffer);
+    }
+
+    if (data->parts[DATE_PART_SEP2]) {
+        dotted_text_layer_set_text(data->parts[DATE_PART_SEP2], settings->ShowYear ? "." : NULL);
+    }
+
+    if (data->parts[DATE_PART_YEAR]) {
         if (settings->ShowYear) {
-            strcat(date_format, ".%y");
+            char year_buffer[8];
+            strftime(year_buffer, sizeof(year_buffer), "%y", tick_time);
+            dotted_text_layer_set_text(data->parts[DATE_PART_YEAR], year_buffer);
+        } else {
+            dotted_text_layer_set_text(data->parts[DATE_PART_YEAR], NULL);
         }
-        strftime(digits_buffer, sizeof(digits_buffer), date_format, tick_time);
+    }
 
-        if (!settings->DateZeroPadding) {
-            char *p = digits_buffer;
-
-            // Now p points to the start of the day digits.
-            if (*p == '0') {
-                memmove(p, p + 1, strlen(p + 1) + 1);
-            }
-
-            // Find the first '.' separator.
-            while (*p && *p != '.') {
-                p++;
-            }
-
-            if (*p == '.') {
-                p++; // Point to the start of the month digits
-                if (*p == '0') {
-                    memmove(p, p + 1, strlen(p + 1) + 1);
-                }
-            }
+    // 2. Apply colors in a loop
+    GColor colors[DATE_PART_COUNT] = {
+        theme->WeekdayTextColor,
+        theme->DateTextColor,
+        theme->DateSeparatorColor,
+        theme->DateTextColor,
+        theme->DateSeparatorColor,
+        theme->DateTextColor
+    };
+    for (int i = 0; i < DATE_PART_COUNT; i++) {
+        if (data->parts[i]) {
+            dotted_text_layer_set_color(data->parts[i], colors[i]);
         }
-        dotted_text_layer_set_text(data->date_digits_layer, digits_buffer);
-        dotted_text_layer_set_color(data->date_digits_layer, theme->DateTextColor);
     }
 
     layer_mark_dirty(container_layer);
@@ -156,30 +202,21 @@ Layer *create_date_layer(LayerBuilder builder) {
     DateLayerData *data = layer_get_data(container);
 
     ClaySettings *settings = clay_get_settings();
-    Theme *theme = theme_get_theme();
     LayerBuilder child_builder = layer_builder_from_rect(container, GRect(0, 0, builder.bounds.size.w, builder.bounds.size.h));
 
-    data->weekday_layer = layer_factory_create_dotted_text_layer(
-        child_builder,
-        theme->WeekdayTextColor,
-        HORIZONTAL_ALIGN_LEFT,
-        VERTICAL_ALIGN_TOP,
-        NULL
-    );
-    data->date_digits_layer = layer_factory_create_dotted_text_layer(
-        child_builder,
-        theme->DateTextColor,
-        HORIZONTAL_ALIGN_LEFT,
-        VERTICAL_ALIGN_TOP,
-        NULL
-    );
-
-    if (settings->DotAutoScale) {
-        dotted_text_layer_set_auto_scale(data->weekday_layer, true);
-        dotted_text_layer_set_auto_scale(data->date_digits_layer, true);
-    } else {
-        dotted_text_layer_set_scale_factor(data->weekday_layer, settings->DotScaleFactor);
-        dotted_text_layer_set_scale_factor(data->date_digits_layer, settings->DotScaleFactor);
+    for (int i = 0; i < DATE_PART_COUNT; i++) {
+        data->parts[i] = layer_factory_create_dotted_text_layer(
+            child_builder,
+            GColorClear, // will be set by update_date_for_layer
+            HORIZONTAL_ALIGN_LEFT,
+            VERTICAL_ALIGN_TOP,
+            (i == DATE_PART_SEP1) ? "." : NULL
+        );
+        if (settings->DotAutoScale) {
+            dotted_text_layer_set_auto_scale(data->parts[i], true);
+        } else {
+            dotted_text_layer_set_scale_factor(data->parts[i], settings->DotScaleFactor);
+        }
     }
 
     update_date_for_layer(container);
@@ -190,11 +227,10 @@ Layer *create_date_layer(LayerBuilder builder) {
 // destroys the date layer
 void destroy_date_layer(Layer *layer) {
     DateLayerData *data = layer_get_data(layer);
-    if (data->weekday_layer) {
-        dotted_text_layer_destroy(data->weekday_layer);
-    }
-    if (data->date_digits_layer) {
-        dotted_text_layer_destroy(data->date_digits_layer);
+    for (int i = 0; i < DATE_PART_COUNT; i++) {
+        if (data->parts[i]) {
+            dotted_text_layer_destroy(data->parts[i]);
+        }
     }
     layer_destroy(layer);
 }

--- a/src/c/ui/layer/weather.c
+++ b/src/c/ui/layer/weather.c
@@ -516,6 +516,12 @@ static void update_weather_for_layer(Layer *weather_container_layer) {
         }
     }
 
+    for (int i = 0; i < 2; i++) {
+        if (layer_data->separators[i] != NULL) {
+            dotted_text_layer_set_color(layer_data->separators[i], theme->WeatherSeparatorColor);
+        }
+    }
+
     layer_mark_dirty(weather_container_layer);
 }
 
@@ -608,7 +614,7 @@ Layer *create_weather_layer(LayerBuilder builder) {
         if (i < 2) {
             data->separators[i] = layer_factory_create_dotted_text_layer(
                 child_builder,
-                GColorLightGray,
+                theme->WeatherSeparatorColor,
                 HORIZONTAL_ALIGN_LEFT,
                 VERTICAL_ALIGN_TOP,
                 NULL

--- a/src/c/ui/layer/weather.h
+++ b/src/c/ui/layer/weather.h
@@ -6,11 +6,7 @@
 
 // Persistent storage key
 #define WEATHER_DATA_KEY PERSIST_KEY_WEATHER_DATA
-#ifdef PBL_PLATFORM_APLITE
-#define WEATHER_FORECAST_MAX_POINTS 50
-#else
 #define WEATHER_FORECAST_MAX_POINTS 100
-#endif
 
 typedef struct WeatherData {
     int CurrentTemperature;

--- a/src/c/ui/layer/weather_forecast.c
+++ b/src/c/ui/layer/weather_forecast.c
@@ -1,27 +1,5 @@
 #include "weather_forecast.h"
 
-#if defined(PBL_PLATFORM_APLITE)
-
-void update_weather_forecast() {
-}
-
-void weather_forecast_layer_update_settings() {
-}
-
-void weather_forecast_tick_update() {
-}
-
-Layer *create_weather_forecast_layer(LayerBuilder builder) {
-    (void) builder;
-    return NULL;
-}
-
-void destroy_weather_forecast_layer(Layer *layer) {
-    (void) layer;
-}
-
-#else
-
 #include <pebble.h>
 #include <string.h>
 
@@ -295,5 +273,3 @@ void destroy_weather_forecast_layer(Layer *layer) {
     }
     layer_destroy(layer);
 }
-
-#endif

--- a/src/c/ui/theme.c
+++ b/src/c/ui/theme.c
@@ -38,6 +38,7 @@ static void set_colors(Theme *theme, enum ThemeEnum themeEnum) {
     theme->TimeTextColor = mainTextColor;
     theme->DateTextColor = mainTextColor;
     theme->WeekdayTextColor = mainTextColor;
+    theme->DateSeparatorColor = mainTextColor;
 
     theme->BatteryOutlineColor = foregroundColor;
     theme->BatteryFillColor = foregroundColor;
@@ -106,6 +107,7 @@ void apply_theme_from_settings(ClaySettings *settings, Window *window) {
         custom_theme.TimeTextColor = settings->TimeTextColor;
         custom_theme.DateTextColor = settings->DateTextColor;
         custom_theme.WeekdayTextColor = settings->WeekdayTextColor;
+        custom_theme.DateSeparatorColor = settings->DateSeparatorColor;
         custom_theme.BatteryOutlineColor = settings->BatteryFrameColor;
         custom_theme.BatteryFillColor = settings->BatteryFillColor;
         custom_theme.BatteryLowColor = settings->BatteryLowColor;

--- a/src/c/ui/theme.c
+++ b/src/c/ui/theme.c
@@ -50,6 +50,7 @@ static void set_colors(Theme *theme, enum ThemeEnum themeEnum) {
     theme->WeatherMinTempColor = GColorPictonBlue;
     theme->WeatherAxisTickColor = GColorDarkGray;
     theme->WeatherIndicatorColor = mainTextColor;
+    theme->WeatherSeparatorColor = GColorLightGray;
 
 #if defined(PBL_COLOR)
     // Forecast Graph Colors
@@ -117,6 +118,7 @@ void apply_theme_from_settings(ClaySettings *settings, Window *window) {
         custom_theme.WeatherMinTempColor = settings->WeatherMinTempColor;
         custom_theme.WeatherAxisTickColor = settings->WeatherAxisTickColor;
         custom_theme.WeatherIndicatorColor = settings->WeatherIndicatorColor;
+        custom_theme.WeatherSeparatorColor = settings->WeatherSeparatorColor;
 
 #if defined(PBL_COLOR)
         custom_theme.ForecastTempColorM10 = settings->ForecastTempColorM10;

--- a/src/c/ui/theme.c
+++ b/src/c/ui/theme.c
@@ -37,6 +37,7 @@ static void set_colors(Theme *theme, enum ThemeEnum themeEnum) {
 
     theme->TimeTextColor = mainTextColor;
     theme->DateTextColor = mainTextColor;
+    theme->WeekdayTextColor = mainTextColor;
 
     theme->BatteryOutlineColor = foregroundColor;
     theme->BatteryFillColor = foregroundColor;
@@ -104,6 +105,7 @@ void apply_theme_from_settings(ClaySettings *settings, Window *window) {
         custom_theme.BackgroundColor = settings->BackgroundColor;
         custom_theme.TimeTextColor = settings->TimeTextColor;
         custom_theme.DateTextColor = settings->DateTextColor;
+        custom_theme.WeekdayTextColor = settings->WeekdayTextColor;
         custom_theme.BatteryOutlineColor = settings->BatteryFrameColor;
         custom_theme.BatteryFillColor = settings->BatteryFillColor;
         custom_theme.BatteryLowColor = settings->BatteryLowColor;

--- a/src/c/ui/theme.h
+++ b/src/c/ui/theme.h
@@ -20,6 +20,7 @@ typedef struct Theme {
     // Date Layer
     GColor DateTextColor;
     GColor WeekdayTextColor;
+    GColor DateSeparatorColor;
 
     // Battery Bar Layer
     GColor BatteryOutlineColor;

--- a/src/c/ui/theme.h
+++ b/src/c/ui/theme.h
@@ -34,6 +34,7 @@ typedef struct Theme {
     GColor WeatherMinTempColor;
     GColor WeatherAxisTickColor;
     GColor WeatherIndicatorColor;
+    GColor WeatherSeparatorColor;
 
 #if defined(PBL_COLOR)
     // Forecast Graph Colors

--- a/src/c/ui/theme.h
+++ b/src/c/ui/theme.h
@@ -19,6 +19,7 @@ typedef struct Theme {
     GColor TimeTextColor;
     // Date Layer
     GColor DateTextColor;
+    GColor WeekdayTextColor;
 
     // Battery Bar Layer
     GColor BatteryOutlineColor;

--- a/src/js-modern/config/configPage.js
+++ b/src/js-modern/config/configPage.js
@@ -443,6 +443,12 @@ export default [
                 "label": "Weekday"
             },
             {
+                "type": "color",
+                "messageKey": "DateSeparatorColor",
+                "defaultValue": "0xAAAAAA",
+                "label": "Date Separator"
+            },
+            {
                 "type": "subheader",
                 "defaultValue": "Battery"
             },

--- a/src/js-modern/config/configPage.js
+++ b/src/js-modern/config/configPage.js
@@ -437,6 +437,12 @@ export default [
                 "label": "Date"
             },
             {
+                "type": "color",
+                "messageKey": "WeekdayTextColor",
+                "defaultValue": "0xFFFFFF",
+                "label": "Weekday"
+            },
+            {
                 "type": "subheader",
                 "defaultValue": "Battery"
             },

--- a/src/js-modern/config/configPage.js
+++ b/src/js-modern/config/configPage.js
@@ -476,21 +476,9 @@ export default [
             },
             {
                 "type": "color",
-                "messageKey": "WeatherTextColor",
-                "defaultValue": "0xFFFFFF",
-                "label": "Weather Forecast"
-            },
-            {
-                "type": "color",
-                "messageKey": "WeatherAxisTickColor",
-                "defaultValue": "0x555555",
-                "label": "Hour Ticks"
-            },
-            {
-                "type": "color",
-                "messageKey": "WeatherIndicatorColor",
-                "defaultValue": "0xFFFFFF",
-                "label": "Current Time Indicator"
+                "messageKey": "WeatherSeparatorColor",
+                "defaultValue": "0xAAAAAA",
+                "label": "Separator"
             },
             {
                 "type": "color",
@@ -509,6 +497,28 @@ export default [
                 "messageKey": "WeatherMinTempColor",
                 "defaultValue": "0x00AAFF",
                 "label": "Min Temperature"
+            },
+            {
+                "type": "subheader",
+                "defaultValue": "Weather Forecast"
+            },
+            {
+                "type": "color",
+                "messageKey": "WeatherTextColor",
+                "defaultValue": "0xFFFFFF",
+                "label": "Weather Forecast"
+            },
+            {
+                "type": "color",
+                "messageKey": "WeatherAxisTickColor",
+                "defaultValue": "0x555555",
+                "label": "Hour Ticks"
+            },
+            {
+                "type": "color",
+                "messageKey": "WeatherIndicatorColor",
+                "defaultValue": "0xFFFFFF",
+                "label": "Current Time Indicator"
             },
             {
                 "type": "subheader",

--- a/src/js-modern/config/configPage.js
+++ b/src/js-modern/config/configPage.js
@@ -476,12 +476,6 @@ export default [
             },
             {
                 "type": "color",
-                "messageKey": "WeatherSeparatorColor",
-                "defaultValue": "0xAAAAAA",
-                "label": "Separator"
-            },
-            {
-                "type": "color",
                 "messageKey": "WeatherMaxTempColor",
                 "defaultValue": "0xFF0000",
                 "label": "Max Temperature"
@@ -497,6 +491,12 @@ export default [
                 "messageKey": "WeatherMinTempColor",
                 "defaultValue": "0x00AAFF",
                 "label": "Min Temperature"
+            },
+            {
+                "type": "color",
+                "messageKey": "WeatherSeparatorColor",
+                "defaultValue": "0xAAAAAA",
+                "label": "Separator"
             },
             {
                 "type": "subheader",

--- a/tests/c/app_messaging_test.c
+++ b/tests/c/app_messaging_test.c
@@ -11,6 +11,7 @@ uint32_t MESSAGE_KEY_Theme = 3;
 uint32_t MESSAGE_KEY_BackgroundColor = 4;
 uint32_t MESSAGE_KEY_TimeTextColor = 5;
 uint32_t MESSAGE_KEY_DateTextColor = 6;
+uint32_t MESSAGE_KEY_WeekdayTextColor = 65;
 uint32_t MESSAGE_KEY_BatteryFrameColor = 7;
 uint32_t MESSAGE_KEY_BatteryFillColor = 8;
 uint32_t MESSAGE_KEY_BatteryLowColor = 9;
@@ -168,12 +169,14 @@ void test_app_messaging_send_app_ready(void) {
 void test_inbox_received_settings_update(void) {
     add_mock_string_tuple(MESSAGE_KEY_Theme, "DARK");
     add_mock_string_tuple(MESSAGE_KEY_BackgroundColor, "0xFFFFFF");
+    add_mock_string_tuple(MESSAGE_KEY_WeekdayTextColor, "0x0000AA");
     add_mock_int_tuple(MESSAGE_KEY_DateZeroPadding, 1);
 
     inbox_received_callback(NULL, NULL);
 
     TEST_ASSERT_EQUAL_STRING("DARK", s_test_settings.ThemeValue);
     TEST_ASSERT_EQUAL_HEX(0xFF, s_test_settings.BackgroundColor.argb);
+    TEST_ASSERT_EQUAL_HEX(0xAA, s_test_settings.WeekdayTextColor.argb);
     TEST_ASSERT_TRUE(s_test_settings.DateZeroPadding);
     TEST_ASSERT_TRUE(s_test_settings.InitialSyncDone);
 }

--- a/tests/c/app_messaging_test.c
+++ b/tests/c/app_messaging_test.c
@@ -22,6 +22,7 @@ uint32_t MESSAGE_KEY_WeatherCurrentTempColor = 12;
 uint32_t MESSAGE_KEY_WeatherMinTempColor = 13;
 uint32_t MESSAGE_KEY_WeatherAxisTickColor = 14;
 uint32_t MESSAGE_KEY_WeatherIndicatorColor = 15;
+uint32_t MESSAGE_KEY_WeatherSeparatorColor = 67;
 uint32_t MESSAGE_KEY_ForecastTempColorM10 = 16;
 uint32_t MESSAGE_KEY_ForecastTempColor0 = 17;
 uint32_t MESSAGE_KEY_ForecastTempColor10 = 18;
@@ -172,6 +173,7 @@ void test_inbox_received_settings_update(void) {
     add_mock_string_tuple(MESSAGE_KEY_BackgroundColor, "0xFFFFFF");
     add_mock_string_tuple(MESSAGE_KEY_WeekdayTextColor, "0x0000AA");
     add_mock_string_tuple(MESSAGE_KEY_DateSeparatorColor, "0x000055");
+    add_mock_string_tuple(MESSAGE_KEY_WeatherSeparatorColor, "0x0000FF");
     add_mock_int_tuple(MESSAGE_KEY_DateZeroPadding, 1);
 
     inbox_received_callback(NULL, NULL);
@@ -180,6 +182,7 @@ void test_inbox_received_settings_update(void) {
     TEST_ASSERT_EQUAL_HEX(0xFF, s_test_settings.BackgroundColor.argb);
     TEST_ASSERT_EQUAL_HEX(0xAA, s_test_settings.WeekdayTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(0x55, s_test_settings.DateSeparatorColor.argb);
+    TEST_ASSERT_EQUAL_HEX(0xFF, s_test_settings.WeatherSeparatorColor.argb);
     TEST_ASSERT_TRUE(s_test_settings.DateZeroPadding);
     TEST_ASSERT_TRUE(s_test_settings.InitialSyncDone);
 }

--- a/tests/c/app_messaging_test.c
+++ b/tests/c/app_messaging_test.c
@@ -12,6 +12,7 @@ uint32_t MESSAGE_KEY_BackgroundColor = 4;
 uint32_t MESSAGE_KEY_TimeTextColor = 5;
 uint32_t MESSAGE_KEY_DateTextColor = 6;
 uint32_t MESSAGE_KEY_WeekdayTextColor = 65;
+uint32_t MESSAGE_KEY_DateSeparatorColor = 66;
 uint32_t MESSAGE_KEY_BatteryFrameColor = 7;
 uint32_t MESSAGE_KEY_BatteryFillColor = 8;
 uint32_t MESSAGE_KEY_BatteryLowColor = 9;
@@ -170,6 +171,7 @@ void test_inbox_received_settings_update(void) {
     add_mock_string_tuple(MESSAGE_KEY_Theme, "DARK");
     add_mock_string_tuple(MESSAGE_KEY_BackgroundColor, "0xFFFFFF");
     add_mock_string_tuple(MESSAGE_KEY_WeekdayTextColor, "0x0000AA");
+    add_mock_string_tuple(MESSAGE_KEY_DateSeparatorColor, "0x000055");
     add_mock_int_tuple(MESSAGE_KEY_DateZeroPadding, 1);
 
     inbox_received_callback(NULL, NULL);
@@ -177,6 +179,7 @@ void test_inbox_received_settings_update(void) {
     TEST_ASSERT_EQUAL_STRING("DARK", s_test_settings.ThemeValue);
     TEST_ASSERT_EQUAL_HEX(0xFF, s_test_settings.BackgroundColor.argb);
     TEST_ASSERT_EQUAL_HEX(0xAA, s_test_settings.WeekdayTextColor.argb);
+    TEST_ASSERT_EQUAL_HEX(0x55, s_test_settings.DateSeparatorColor.argb);
     TEST_ASSERT_TRUE(s_test_settings.DateZeroPadding);
     TEST_ASSERT_TRUE(s_test_settings.InitialSyncDone);
 }

--- a/tests/c/date_test.c
+++ b/tests/c/date_test.c
@@ -21,31 +21,70 @@ Theme *theme_get_theme() { return &s_theme; }
 // DottedTextLayer mocks
 static char s_last_dotted_text[32];
 static char s_last_weekday_text[16] = "";
-static char s_last_digits_text[16] = "";
+static char s_last_day_text[8] = "";
+static char s_last_sep1_text[4] = "";
+static char s_last_month_text[8] = "";
+static char s_last_sep2_text[4] = "";
+static char s_last_year_text[8] = "";
+
 static DottedTextLayer *s_mock_weekday_layer = NULL;
-static DottedTextLayer *s_mock_digits_layer = NULL;
+static DottedTextLayer *s_mock_day_layer = NULL;
+static DottedTextLayer *s_mock_sep1_layer = NULL;
+static DottedTextLayer *s_mock_month_layer = NULL;
+static DottedTextLayer *s_mock_sep2_layer = NULL;
+static DottedTextLayer *s_mock_year_layer = NULL;
 
 void dotted_text_layer_set_text(DottedTextLayer *dotted_text_layer, char *text) {
+    char *dest = NULL;
+    size_t size = 0;
     if (dotted_text_layer == s_mock_weekday_layer) {
+        dest = s_last_weekday_text;
+        size = sizeof(s_last_weekday_text);
+    } else if (dotted_text_layer == s_mock_day_layer) {
+        dest = s_last_day_text;
+        size = sizeof(s_last_day_text);
+    } else if (dotted_text_layer == s_mock_sep1_layer) {
+        dest = s_last_sep1_text;
+        size = sizeof(s_last_sep1_text);
+    } else if (dotted_text_layer == s_mock_month_layer) {
+        dest = s_last_month_text;
+        size = sizeof(s_last_month_text);
+    } else if (dotted_text_layer == s_mock_sep2_layer) {
+        dest = s_last_sep2_text;
+        size = sizeof(s_last_sep2_text);
+    } else if (dotted_text_layer == s_mock_year_layer) {
+        dest = s_last_year_text;
+        size = sizeof(s_last_year_text);
+    }
+
+    if (dest) {
         if (text) {
-            strncpy(s_last_weekday_text, text, sizeof(s_last_weekday_text) - 1);
-            s_last_weekday_text[sizeof(s_last_weekday_text) - 1] = '\0';
+            strncpy(dest, text, size - 1);
+            dest[size - 1] = '\0';
         } else {
-            s_last_weekday_text[0] = '\0';
-        }
-    } else if (dotted_text_layer == s_mock_digits_layer) {
-        if (text) {
-            strncpy(s_last_digits_text, text, sizeof(s_last_digits_text) - 1);
-            s_last_digits_text[sizeof(s_last_digits_text) - 1] = '\0';
-        } else {
-            s_last_digits_text[0] = '\0';
+            dest[0] = '\0';
         }
     }
 
+    s_last_dotted_text[0] = '\0';
     if (s_last_weekday_text[0] != '\0') {
-        snprintf(s_last_dotted_text, sizeof(s_last_dotted_text), "%s %s", s_last_weekday_text, s_last_digits_text);
-    } else {
-        snprintf(s_last_dotted_text, sizeof(s_last_dotted_text), "%s", s_last_digits_text);
+        strcat(s_last_dotted_text, s_last_weekday_text);
+        strcat(s_last_dotted_text, " ");
+    }
+    if (s_last_day_text[0] != '\0') {
+        strcat(s_last_dotted_text, s_last_day_text);
+    }
+    if (s_last_sep1_text[0] != '\0') {
+        strcat(s_last_dotted_text, s_last_sep1_text);
+    }
+    if (s_last_month_text[0] != '\0') {
+        strcat(s_last_dotted_text, s_last_month_text);
+    }
+    if (s_last_sep2_text[0] != '\0') {
+        strcat(s_last_dotted_text, s_last_sep2_text);
+    }
+    if (s_last_year_text[0] != '\0') {
+        strcat(s_last_dotted_text, s_last_year_text);
     }
 }
 void dotted_text_layer_set_color(DottedTextLayer *dotted_text_layer, GColor color) {}
@@ -78,8 +117,19 @@ DottedTextLayer *layer_factory_create_dotted_text_layer(LayerBuilder builder, GC
     DottedTextLayer *layer = (DottedTextLayer *)layer_create(builder.bounds);
     if (s_mock_weekday_layer == NULL) {
         s_mock_weekday_layer = layer;
-    } else if (s_mock_digits_layer == NULL) {
-        s_mock_digits_layer = layer;
+    } else if (s_mock_day_layer == NULL) {
+        s_mock_day_layer = layer;
+    } else if (s_mock_sep1_layer == NULL) {
+        s_mock_sep1_layer = layer;
+    } else if (s_mock_month_layer == NULL) {
+        s_mock_month_layer = layer;
+    } else if (s_mock_sep2_layer == NULL) {
+        s_mock_sep2_layer = layer;
+    } else if (s_mock_year_layer == NULL) {
+        s_mock_year_layer = layer;
+    }
+    if (text) {
+        dotted_text_layer_set_text(layer, (char *)text);
     }
     return layer;
 }
@@ -112,9 +162,17 @@ void setUp(void) {
     s_row_count = 0;
     memset(s_last_dotted_text, 0, sizeof(s_last_dotted_text));
     memset(s_last_weekday_text, 0, sizeof(s_last_weekday_text));
-    memset(s_last_digits_text, 0, sizeof(s_last_digits_text));
+    memset(s_last_day_text, 0, sizeof(s_last_day_text));
+    memset(s_last_sep1_text, 0, sizeof(s_last_sep1_text));
+    memset(s_last_month_text, 0, sizeof(s_last_month_text));
+    memset(s_last_sep2_text, 0, sizeof(s_last_sep2_text));
+    memset(s_last_year_text, 0, sizeof(s_last_year_text));
     s_mock_weekday_layer = NULL;
-    s_mock_digits_layer = NULL;
+    s_mock_day_layer = NULL;
+    s_mock_sep1_layer = NULL;
+    s_mock_month_layer = NULL;
+    s_mock_sep2_layer = NULL;
+    s_mock_year_layer = NULL;
 
     // Default mock date: January 1, 2026 (Thursday)
     memset(&s_mock_tm_val, 0, sizeof(struct tm));
@@ -149,7 +207,7 @@ static void get_expected_date(char *dest, size_t dest_size, bool show_weekday, b
         memmove(&dest[idxToDel], &dest[idxToDel + 1], strlen(dest) - idxToDel);
         if (weekday_upper) {
             for (int j = 0; j < 2; j++) {
-                dest[j] = upper(dest[j]);
+                dest[j] = UPPER(dest[j]);
             }
         }
     }

--- a/tests/c/date_test.c
+++ b/tests/c/date_test.c
@@ -20,11 +20,38 @@ Theme *theme_get_theme() { return &s_theme; }
 
 // DottedTextLayer mocks
 static char s_last_dotted_text[32];
+static char s_last_weekday_text[16] = "";
+static char s_last_digits_text[16] = "";
+static DottedTextLayer *s_mock_weekday_layer = NULL;
+static DottedTextLayer *s_mock_digits_layer = NULL;
+
 void dotted_text_layer_set_text(DottedTextLayer *dotted_text_layer, char *text) {
-    if (text) strncpy(s_last_dotted_text, text, sizeof(s_last_dotted_text));
+    if (dotted_text_layer == s_mock_weekday_layer) {
+        if (text) {
+            strncpy(s_last_weekday_text, text, sizeof(s_last_weekday_text) - 1);
+            s_last_weekday_text[sizeof(s_last_weekday_text) - 1] = '\0';
+        } else {
+            s_last_weekday_text[0] = '\0';
+        }
+    } else if (dotted_text_layer == s_mock_digits_layer) {
+        if (text) {
+            strncpy(s_last_digits_text, text, sizeof(s_last_digits_text) - 1);
+            s_last_digits_text[sizeof(s_last_digits_text) - 1] = '\0';
+        } else {
+            s_last_digits_text[0] = '\0';
+        }
+    }
+
+    if (s_last_weekday_text[0] != '\0') {
+        snprintf(s_last_dotted_text, sizeof(s_last_dotted_text), "%s %s", s_last_weekday_text, s_last_digits_text);
+    } else {
+        snprintf(s_last_dotted_text, sizeof(s_last_dotted_text), "%s", s_last_digits_text);
+    }
 }
+void dotted_text_layer_set_color(DottedTextLayer *dotted_text_layer, GColor color) {}
 void dotted_text_layer_set_auto_scale(DottedTextLayer *dotted_text_layer, bool enabled) {}
 void dotted_text_layer_set_scale_factor(DottedTextLayer *dotted_text_layer, float scale) {}
+int dotted_text_layer_get_content_width(DottedTextLayer *dotted_text_layer) { return 10; }
 void dotted_text_layer_destroy(DottedTextLayer *dotted_text_layer) { free(dotted_text_layer); }
 
 // ui_state.h mocks
@@ -36,10 +63,27 @@ WidgetId ui_state_get_widget_id(int row) { return s_mock_widgets[row]; }
 Layer* ui_state_get_layer(int row) { return s_mock_layers[row]; }
 
 // layer_factory.h mocks
-DottedTextLayer *layer_factory_create_dotted_text_layer(LayerBuilder builder, GColor color, HorizontalAlignment h_align, VerticalAlignment v_align, const char *text) {
-    DottedTextLayer *layer = layer_create(builder.bounds);
+LayerBuilder layer_builder_from_rect(Layer *parent, GRect bounds) {
+    return (LayerBuilder){
+        .parent = parent,
+        .bounds = bounds,
+    };
+}
+Layer* layer_factory_create_custom_layer_with_data(LayerBuilder builder, LayerUpdateProc update_proc, size_t data_size) {
+    Layer *layer = layer_create_with_data(builder.bounds, data_size);
+    layer_set_update_proc(layer, update_proc);
     return layer;
 }
+DottedTextLayer *layer_factory_create_dotted_text_layer(LayerBuilder builder, GColor color, HorizontalAlignment h_align, VerticalAlignment v_align, const char *text) {
+    DottedTextLayer *layer = (DottedTextLayer *)layer_create(builder.bounds);
+    if (s_mock_weekday_layer == NULL) {
+        s_mock_weekday_layer = layer;
+    } else if (s_mock_digits_layer == NULL) {
+        s_mock_digits_layer = layer;
+    }
+    return layer;
+}
+void layer_set_frame(Layer *layer, GRect frame) {}
 
 #include <time.h>
 
@@ -67,6 +111,10 @@ void setUp(void) {
     s_settings.DateZeroPadding = true;
     s_row_count = 0;
     memset(s_last_dotted_text, 0, sizeof(s_last_dotted_text));
+    memset(s_last_weekday_text, 0, sizeof(s_last_weekday_text));
+    memset(s_last_digits_text, 0, sizeof(s_last_digits_text));
+    s_mock_weekday_layer = NULL;
+    s_mock_digits_layer = NULL;
 
     // Default mock date: January 1, 2026 (Thursday)
     memset(&s_mock_tm_val, 0, sizeof(struct tm));

--- a/tests/c/theme_test.c
+++ b/tests/c/theme_test.c
@@ -24,6 +24,7 @@ void test_set_theme_dark(void) {
     TEST_ASSERT_EQUAL_HEX(GColorBlack.argb, theme->BackgroundColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorWhite.argb, theme->TimeTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorWhite.argb, theme->DateTextColor.argb);
+    TEST_ASSERT_EQUAL_HEX(GColorWhite.argb, theme->WeekdayTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorWhite.argb, theme->BatteryOutlineColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorWhite.argb, theme->BatteryFillColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorRed.argb, theme->BatteryLowColor.argb);
@@ -59,6 +60,7 @@ void test_set_theme_light(void) {
     TEST_ASSERT_EQUAL_HEX(GColorWhite.argb, theme->BackgroundColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorBlack.argb, theme->TimeTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorBlack.argb, theme->DateTextColor.argb);
+    TEST_ASSERT_EQUAL_HEX(GColorBlack.argb, theme->WeekdayTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorBlack.argb, theme->BatteryOutlineColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorBlack.argb, theme->BatteryFillColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorRed.argb, theme->BatteryLowColor.argb);
@@ -92,6 +94,7 @@ void test_init_custom_theme(void) {
     custom_theme.BackgroundColor = GColorRed;
     custom_theme.TimeTextColor = GColorGreen;
     custom_theme.DateTextColor = GColorBlue;
+    custom_theme.WeekdayTextColor = GColorOrange;
     custom_theme.BatteryOutlineColor = GColorYellow;
     custom_theme.BatteryFillColor = GColorCyan;
     custom_theme.BatteryLowColor = GColorVividCerulean;
@@ -125,6 +128,7 @@ void test_init_custom_theme(void) {
     TEST_ASSERT_EQUAL_HEX(GColorRed.argb, theme->BackgroundColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorGreen.argb, theme->TimeTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorBlue.argb, theme->DateTextColor.argb);
+    TEST_ASSERT_EQUAL_HEX(GColorOrange.argb, theme->WeekdayTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorYellow.argb, theme->BatteryOutlineColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorCyan.argb, theme->BatteryFillColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorMagenta.argb, theme->WeatherTextColor.argb);
@@ -186,6 +190,7 @@ void test_apply_theme_from_settings_custom(void) {
     strcpy(settings.ThemeValue, THEME_CUSTOM_STR);
     settings.BackgroundColor = GColorRed;
     settings.TimeTextColor = GColorGreen;
+    settings.WeekdayTextColor = GColorBlue;
     settings.ShowSeconds = false;
 
     apply_theme_from_settings(&settings, NULL);
@@ -194,6 +199,7 @@ void test_apply_theme_from_settings_custom(void) {
     TEST_ASSERT_EQUAL(CUSTOM, theme->CurrentThemeEnum);
     TEST_ASSERT_EQUAL_HEX(GColorRed.argb, theme->BackgroundColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorGreen.argb, theme->TimeTextColor.argb);
+    TEST_ASSERT_EQUAL_HEX(GColorBlue.argb, theme->WeekdayTextColor.argb);
 }
 
 // Test apply_theme_from_settings with default (empty) theme value

--- a/tests/c/theme_test.c
+++ b/tests/c/theme_test.c
@@ -25,6 +25,7 @@ void test_set_theme_dark(void) {
     TEST_ASSERT_EQUAL_HEX(GColorWhite.argb, theme->TimeTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorWhite.argb, theme->DateTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorWhite.argb, theme->WeekdayTextColor.argb);
+    TEST_ASSERT_EQUAL_HEX(GColorWhite.argb, theme->DateSeparatorColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorWhite.argb, theme->BatteryOutlineColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorWhite.argb, theme->BatteryFillColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorRed.argb, theme->BatteryLowColor.argb);
@@ -61,6 +62,7 @@ void test_set_theme_light(void) {
     TEST_ASSERT_EQUAL_HEX(GColorBlack.argb, theme->TimeTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorBlack.argb, theme->DateTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorBlack.argb, theme->WeekdayTextColor.argb);
+    TEST_ASSERT_EQUAL_HEX(GColorBlack.argb, theme->DateSeparatorColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorBlack.argb, theme->BatteryOutlineColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorBlack.argb, theme->BatteryFillColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorRed.argb, theme->BatteryLowColor.argb);
@@ -95,6 +97,7 @@ void test_init_custom_theme(void) {
     custom_theme.TimeTextColor = GColorGreen;
     custom_theme.DateTextColor = GColorBlue;
     custom_theme.WeekdayTextColor = GColorOrange;
+    custom_theme.DateSeparatorColor = GColorMagenta;
     custom_theme.BatteryOutlineColor = GColorYellow;
     custom_theme.BatteryFillColor = GColorCyan;
     custom_theme.BatteryLowColor = GColorVividCerulean;
@@ -129,6 +132,7 @@ void test_init_custom_theme(void) {
     TEST_ASSERT_EQUAL_HEX(GColorGreen.argb, theme->TimeTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorBlue.argb, theme->DateTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorOrange.argb, theme->WeekdayTextColor.argb);
+    TEST_ASSERT_EQUAL_HEX(GColorMagenta.argb, theme->DateSeparatorColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorYellow.argb, theme->BatteryOutlineColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorCyan.argb, theme->BatteryFillColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorMagenta.argb, theme->WeatherTextColor.argb);
@@ -191,6 +195,7 @@ void test_apply_theme_from_settings_custom(void) {
     settings.BackgroundColor = GColorRed;
     settings.TimeTextColor = GColorGreen;
     settings.WeekdayTextColor = GColorBlue;
+    settings.DateSeparatorColor = GColorOrange;
     settings.ShowSeconds = false;
 
     apply_theme_from_settings(&settings, NULL);
@@ -200,6 +205,7 @@ void test_apply_theme_from_settings_custom(void) {
     TEST_ASSERT_EQUAL_HEX(GColorRed.argb, theme->BackgroundColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorGreen.argb, theme->TimeTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorBlue.argb, theme->WeekdayTextColor.argb);
+    TEST_ASSERT_EQUAL_HEX(GColorOrange.argb, theme->DateSeparatorColor.argb);
 }
 
 // Test apply_theme_from_settings with default (empty) theme value

--- a/tests/c/theme_test.c
+++ b/tests/c/theme_test.c
@@ -32,6 +32,7 @@ void test_set_theme_dark(void) {
     TEST_ASSERT_EQUAL_HEX(GColorWhite.argb, theme->WeatherTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorDarkGray.argb, theme->WeatherAxisTickColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorWhite.argb, theme->WeatherIndicatorColor.argb);
+    TEST_ASSERT_EQUAL_HEX(GColorLightGray.argb, theme->WeatherSeparatorColor.argb);
 
 #if defined(PBL_COLOR)
     TEST_ASSERT_EQUAL_HEX(GColorBlueMoon.argb, theme->ForecastTempColorM10.argb);
@@ -69,6 +70,7 @@ void test_set_theme_light(void) {
     TEST_ASSERT_EQUAL_HEX(GColorBlack.argb, theme->WeatherTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorDarkGray.argb, theme->WeatherAxisTickColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorBlack.argb, theme->WeatherIndicatorColor.argb);
+    TEST_ASSERT_EQUAL_HEX(GColorLightGray.argb, theme->WeatherSeparatorColor.argb);
 
 #if defined(PBL_COLOR)
     TEST_ASSERT_EQUAL_HEX(GColorBlueMoon.argb, theme->ForecastTempColorM10.argb);
@@ -104,6 +106,7 @@ void test_init_custom_theme(void) {
     custom_theme.WeatherTextColor = GColorMagenta;
     custom_theme.WeatherAxisTickColor = GColorDarkGray;
     custom_theme.WeatherIndicatorColor = GColorWhite;
+    custom_theme.WeatherSeparatorColor = GColorLightGray;
 
 #if defined(PBL_COLOR)
     custom_theme.ForecastTempColorM10 = GColorBlueMoon;
@@ -136,6 +139,7 @@ void test_init_custom_theme(void) {
     TEST_ASSERT_EQUAL_HEX(GColorYellow.argb, theme->BatteryOutlineColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorCyan.argb, theme->BatteryFillColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorMagenta.argb, theme->WeatherTextColor.argb);
+    TEST_ASSERT_EQUAL_HEX(GColorLightGray.argb, theme->WeatherSeparatorColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorOrange.argb, theme->StepcountTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorPurple.argb, theme->HeartrateTextColor.argb);
 }
@@ -196,6 +200,7 @@ void test_apply_theme_from_settings_custom(void) {
     settings.TimeTextColor = GColorGreen;
     settings.WeekdayTextColor = GColorBlue;
     settings.DateSeparatorColor = GColorOrange;
+    settings.WeatherSeparatorColor = GColorLightGray;
     settings.ShowSeconds = false;
 
     apply_theme_from_settings(&settings, NULL);
@@ -206,6 +211,7 @@ void test_apply_theme_from_settings_custom(void) {
     TEST_ASSERT_EQUAL_HEX(GColorGreen.argb, theme->TimeTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorBlue.argb, theme->WeekdayTextColor.argb);
     TEST_ASSERT_EQUAL_HEX(GColorOrange.argb, theme->DateSeparatorColor.argb);
+    TEST_ASSERT_EQUAL_HEX(GColorLightGray.argb, theme->WeatherSeparatorColor.argb);
 }
 
 // Test apply_theme_from_settings with default (empty) theme value


### PR DESCRIPTION
# Customize Weekday & Date/Weather Separator Colors & Drop Aplite Support

This PR introduces new color configuration options for customization, refactors the Date widget into a dynamically positioned multi-layer component, and drops support for the legacy `aplite` target platform to simplify the codebase.

## Key Changes

### 1. New Custom Color Options
Added three new configurable color pickers under the custom colors section in the Settings UI:
* **`WeekdayTextColor`**: Allows setting a custom color for the weekday abbreviation separate from the numeric date.
* **`DateSeparatorColor`**: Allows coloring the date dots (`.`) independently.
* **`WeatherSeparatorColor`**: Allows coloring the separator lines (`|`) in the weather widget (defaults to `GColorLightGray`).

### 2. Multi-Part Date Layer Refactoring (`src/c/ui/layer/date.c`)
* Refactored the date widget into a container layer composed of 6 sub-layers (`DATE_PART_WEEKDAY`, `DATE_PART_DAY`, `DATE_PART_SEP1`, `DATE_PART_MONTH`, `DATE_PART_SEP2`, `DATE_PART_YEAR`).
* Implemented dynamic positioning in the layout process to measure widths and space components dynamically, ensuring pixel-perfect layout and rendering alignment.
* Applied theme-specific colors to each individual component during updates.

### 3. Settings UI Redesign
* Regrouped the Custom Colors section. Separated the Weather and Weather Forecast options.
* Created a dedicated **`Weather Forecast`** sub-section containing the forecast text, hour ticks, and current time indicator color picker fields.

### 4. Dropped Support for legacy `aplite` Platform
* Removed `"aplite"` target platform from `package.json`.
* Removed `PBL_PLATFORM_APLITE` preprocessor guards, checks, and stub compilation blocks from settings logs, weather forecast points, and forecast drawing layers to clean up memory optimization workarounds.

## Verification

### Unit Tests
* Updated tests in [tests/c/theme_test.c](file:///home/markus/CLionProjects/Watchface-No.-2/tests/c/theme_test.c) and [tests/c/app_messaging_test.c](file:///home/markus/CLionProjects/Watchface-No.-2/tests/c/app_messaging_test.c) to cover the new color configurations.
* All 156 host C unit tests passed successfully (`just test-c`).
* All Jest JavaScript tests passed successfully (`just test-js`).

### Build
* Watchface compiles successfully for basalt, diorite, flint, and emery platforms (`just clean && just build`).
